### PR TITLE
 Set default configs for gateway APIs (issue #69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ GATEWAY_PORT=8000
 # Uncomment and change to "true" inorder to enable gateway routes
 
 #gateway_routes_enable_api=false
+#gateway_routes_enable_network=false
 #gateway_routes_enable_status=false
 #gateway_routes_enable_delegate=false
 #gateway_routes_enable_mine=false

--- a/.env.testnet
+++ b/.env.testnet
@@ -9,6 +9,7 @@ GATEWAY_PORT=8000
 # Uncomment and change to "true" inorder to enable gateway routes
 
 #gateway_routes_enable_api=false
+#gateway_routes_enable_network=false
 #gateway_routes_enable_status=false
 #gateway_routes_enable_delegate=false
 #gateway_routes_enable_mine=false

--- a/config/global/default.gateway.conf.json
+++ b/config/global/default.gateway.conf.json
@@ -4,12 +4,12 @@
   "routes": {
     "enable": {
       "api": true,
-      "network": true,
+      "network": false,
       "status": true,
-      "delegate": true,
+      "delegate": false,
       "mine": true,
-      "crashReport": true,
-      "ifconfig": true
+      "crashReport": false,
+      "ifconfig": false
     }
   }
 }

--- a/src/gateway/configurations.ts
+++ b/src/gateway/configurations.ts
@@ -29,6 +29,9 @@ export function load(): GatewayGlobalConfigs{
   if(!!process.env.gateway_routes_enable_api)
     configs.routes.enable.api = parseBool(process.env.gateway_routes_enable_api)
 
+  if(!!process.env.gateway_routes_enable_network)
+    configs.routes.enable.network = parseBool(process.env.gateway_routes_enable_network)
+
   if(!!process.env.gateway_routes_enable_status)
     configs.routes.enable.status = parseBool(process.env.gateway_routes_enable_status)
 


### PR DESCRIPTION
Default value for these routes set to false but must be enabled on related nodes:
configs.routes.enable.network should be set true on deployer nodes
configs.routes.enable.delegate should be set to true on delegate nodes
configs.routes.enable.ifconfig should be set to true on delegate nodes
configs.routes.enable.crashReport should be set to true on crash report collector nodes (id:4)